### PR TITLE
[RWS-40] Add support for JSR-303 Message Validation

### DIFF
--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -58,6 +58,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 

--- a/functional-tests/src/main/java/io/github/elpis/reactive/websockets/context/advice/GlobalWebSocketErrorHandler.java
+++ b/functional-tests/src/main/java/io/github/elpis/reactive/websockets/context/advice/GlobalWebSocketErrorHandler.java
@@ -1,6 +1,7 @@
 package io.github.elpis.reactive.websockets.context.advice;
 
 import io.github.elpis.reactive.websockets.web.annotation.WebSocketAdvice;
+import jakarta.validation.ConstraintViolationException;
 import java.io.IOException;
 import java.util.Map;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,5 +29,10 @@ public class GlobalWebSocketErrorHandler {
   @ExceptionHandler
   public void handleIOException(final IOException __) {
     // Void handler - just logs, doesn't send response to client
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public Map<String, Object> handleAllOtherErrors(final ConstraintViolationException ex) {
+    return Map.of("error", "VALIDATION_FAILED", "message", ex.getMessage());
   }
 }

--- a/functional-tests/src/main/java/io/github/elpis/reactive/websockets/context/model/ValidatedMessage.java
+++ b/functional-tests/src/main/java/io/github/elpis/reactive/websockets/context/model/ValidatedMessage.java
@@ -1,0 +1,5 @@
+package io.github.elpis.reactive.websockets.context.model;
+
+import jakarta.validation.constraints.Email;
+
+public record ValidatedMessage(@Email String username) {}

--- a/functional-tests/src/main/java/io/github/elpis/reactive/websockets/context/resource/data/JsonBodySocketResource.java
+++ b/functional-tests/src/main/java/io/github/elpis/reactive/websockets/context/resource/data/JsonBodySocketResource.java
@@ -3,8 +3,10 @@ package io.github.elpis.reactive.websockets.context.resource.data;
 import io.github.elpis.reactive.websockets.context.model.TestChatMessage;
 import io.github.elpis.reactive.websockets.context.model.TestMessage;
 import io.github.elpis.reactive.websockets.context.model.TestUserMessage;
+import io.github.elpis.reactive.websockets.context.model.ValidatedMessage;
 import io.github.elpis.reactive.websockets.web.annotation.MessageEndpoint;
 import io.github.elpis.reactive.websockets.web.annotation.OnMessage;
+import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -108,5 +110,13 @@ public class JsonBodySocketResource {
     return message
         .doOnNext(msg -> log.info("Raw (Mono): {}", msg.getPayloadAsText()))
         .map(msg -> "Raw (Mono): " + msg.getPayloadAsText());
+  }
+
+  @OnMessage("/validated")
+  public Flux<String> receiveValidatedMessages(
+      @RequestBody @Valid final Flux<ValidatedMessage> messages) {
+    return messages
+        .doOnNext(msg -> log.info("Validated Message: {}", msg))
+        .map(msg -> "Validated Message: " + msg);
   }
 }

--- a/functional-tests/src/test/java/io/github/elpis/reactive/websockets/functional/data/JsonBodySocketTest.java
+++ b/functional-tests/src/test/java/io/github/elpis/reactive/websockets/functional/data/JsonBodySocketTest.java
@@ -1,11 +1,14 @@
 package io.github.elpis.reactive.websockets.functional.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.elpis.reactive.websockets.context.BootStarter;
 import io.github.elpis.reactive.websockets.context.model.TestChatMessage;
 import io.github.elpis.reactive.websockets.context.model.TestMessage;
 import io.github.elpis.reactive.websockets.context.model.TestUserMessage;
+import io.github.elpis.reactive.websockets.context.model.ValidatedMessage;
 import io.github.elpis.reactive.websockets.context.resource.data.JsonBodySocketResource;
 import io.github.elpis.reactive.websockets.functional.BaseWebSocketTest;
 import java.time.Duration;
@@ -402,6 +405,40 @@ class JsonBodySocketTest extends BaseWebSocketTest {
 
     // verify
     Thread.sleep(1000);
+  }
+
+  @Test
+  void testPojoWithValidation() throws Exception {
+    // given
+    final String path = "/json/validated";
+    final ValidatedMessage validatedMessage = new ValidatedMessage("definitelyNotEmail");
+
+    final Mono<String> data = Mono.just(validatedMessage).map(this::toJson);
+
+    final Sinks.One<String> sink = Sinks.one();
+
+    // test
+    this.withClient(
+            path,
+            session ->
+                session
+                    .send(data.map(session::textMessage))
+                    .thenMany(
+                        session
+                            .receive()
+                            .doOnNext(value -> sink.tryEmitValue(value.getPayloadAsText())))
+                    .then())
+        .subscribe();
+
+    // verify
+    StepVerifier.create(sink.asMono())
+        .assertNext(
+            value ->
+                assertThat(value)
+                    .contains("username: must be a well-formed email address")
+                    .contains("VALIDATION_FAILED"))
+        .expectComplete()
+        .verify(DEFAULT_FAST_TEST_FALLBACK);
   }
 
   /** Helper method to convert objects to JSON. */

--- a/functional-tests/src/test/java/io/github/elpis/reactive/websockets/unit/validation/ReactiveJSR303ValidationHandlerTest.java
+++ b/functional-tests/src/test/java/io/github/elpis/reactive/websockets/unit/validation/ReactiveJSR303ValidationHandlerTest.java
@@ -1,0 +1,83 @@
+package io.github.elpis.reactive.websockets.unit.validation;
+
+import io.github.elpis.reactive.websockets.config.context.ReactiveWebSocketValidationConfiguration;
+import io.github.elpis.reactive.websockets.handler.validation.ReactiveJSR303ValidationHandler;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ReactiveWebSocketValidationConfiguration.class)
+class ReactiveJSR303ValidationHandlerTest {
+  private static final String MODEL = "Tesla Model S";
+  private static final String BLANK = "";
+
+  @Autowired private ReactiveJSR303ValidationHandler validationHandler;
+
+  @Test
+  void testValidationWithMonoPasses() {
+    // given
+    final Car car = new Car(MODEL);
+
+    // test
+    final Mono<Car> validated = validationHandler.validate(car);
+
+    // then
+    StepVerifier.create(validated)
+        .expectNext(car)
+        .expectComplete()
+        .verify(StepVerifier.DEFAULT_VERIFY_TIMEOUT);
+  }
+
+  @Test
+  void testValidationWithMonoFails() {
+    // given
+    final Car car = new Car(BLANK);
+
+    // test
+    final Mono<Car> validated = validationHandler.validate(car);
+
+    // then
+    StepVerifier.create(validated)
+        .expectError(ConstraintViolationException.class)
+        .verify(StepVerifier.DEFAULT_VERIFY_TIMEOUT);
+  }
+
+  @Test
+  void testValidationWithFluxPasses() {
+    // given
+    final Car car = new Car(MODEL);
+
+    // test
+    final Flux<Car> validated = validationHandler.validateFlux(car);
+
+    // then
+    StepVerifier.create(validated)
+        .expectNext(car)
+        .expectComplete()
+        .verify(StepVerifier.DEFAULT_VERIFY_TIMEOUT);
+  }
+
+  @Test
+  void testValidationWithFluxFails() {
+    // given
+    final Car car = new Car(BLANK);
+
+    // test
+    final Flux<Car> validated = validationHandler.validateFlux(car);
+
+    // then
+    StepVerifier.create(validated)
+        .expectError(ConstraintViolationException.class)
+        .verify(StepVerifier.DEFAULT_VERIFY_TIMEOUT);
+  }
+
+  record Car(@NotBlank String model) {}
+}

--- a/reactive-websockets-core/pom.xml
+++ b/reactive-websockets-core/pom.xml
@@ -108,6 +108,12 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>compile</scope>

--- a/reactive-websockets-core/src/main/java/io/github/elpis/reactive/websockets/handler/validation/ReactiveJSR303ValidationHandler.java
+++ b/reactive-websockets-core/src/main/java/io/github/elpis/reactive/websockets/handler/validation/ReactiveJSR303ValidationHandler.java
@@ -1,0 +1,58 @@
+package io.github.elpis.reactive.websockets.handler.validation;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import java.util.Set;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Handler for performing JSR-303 bean validation in a reactive context.
+ *
+ * <p>This class uses a Validator to validate objects and returns the results as reactive Mono or
+ * Flux streams. If validation fails, a ConstraintViolationException is emitted.
+ *
+ * @author Phillip J. Fry
+ * @since 1.0.0
+ */
+public final class ReactiveJSR303ValidationHandler {
+  private final Validator validator;
+
+  public ReactiveJSR303ValidationHandler(final Validator validator) {
+    this.validator = validator;
+  }
+
+  /**
+   * Validates the given object and returns a Mono that emits the object if valid, or an error if
+   * validation fails.
+   *
+   * @param <T> the type of the object to validate
+   * @param object the object to validate
+   * @return a Mono emitting the validated object or an error
+   * @throws ConstraintViolationException if validation fails
+   */
+  public <T> Mono<T> validate(final T object) {
+    return Mono.defer(
+        () -> {
+          Set<ConstraintViolation<T>> violations = validator.validate(object);
+          if (!violations.isEmpty()) {
+            return Mono.error(new ConstraintViolationException(violations));
+          }
+          return Mono.just(object);
+        });
+  }
+
+  /**
+   * Validates the given object and returns a Flux that emits the object if valid, or an error if
+   * validation fails.
+   *
+   * @param <T> the type of the object to validate
+   * @param object the object to validate
+   * @return a Flux emitting the validated object or an error
+   * @throws ConstraintViolationException if validation fails
+   */
+  public <T> Flux<T> validateFlux(final T object) {
+    return this.validate(object).flux();
+  }
+}

--- a/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/ReactiveWebSocketAutoConfiguration.java
+++ b/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/ReactiveWebSocketAutoConfiguration.java
@@ -4,6 +4,7 @@ import static io.github.elpis.reactive.websockets.Constants.HANDLER_ORDER;
 
 import io.github.elpis.reactive.websockets.config.context.ReactiveWebSocketContextInitializingConfiguration;
 import io.github.elpis.reactive.websockets.config.context.ReactiveWebSocketParameterResolverConfiguration;
+import io.github.elpis.reactive.websockets.config.context.ReactiveWebSocketValidationConfiguration;
 import io.github.elpis.reactive.websockets.config.event.ReactiveWebSocketEventConfiguration;
 import io.github.elpis.reactive.websockets.config.flowcontrol.ReactiveWebSocketFlowControlConfiguration;
 import io.github.elpis.reactive.websockets.config.maintenance.ReactiveWebSocketRegistryMaintenanceConfiguration;
@@ -58,7 +59,8 @@ import reactor.util.context.Context;
   ReactiveWebSocketRegistryMaintenanceConfiguration.class,
   ReactiveWebSocketMappingConfiguration.class,
   ReactiveWebSocketParameterResolverConfiguration.class,
-  ReactiveWebSocketContextInitializingConfiguration.class
+  ReactiveWebSocketContextInitializingConfiguration.class,
+  ReactiveWebSocketValidationConfiguration.class,
 })
 public class ReactiveWebSocketAutoConfiguration {
 

--- a/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/context/ReactiveWebSocketParameterResolverConfiguration.java
+++ b/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/context/ReactiveWebSocketParameterResolverConfiguration.java
@@ -2,14 +2,19 @@ package io.github.elpis.reactive.websockets.config.context;
 
 import io.github.elpis.reactive.websockets.context.resolver.ReactiveWebSocketMethodParameterResolver;
 import io.github.elpis.reactive.websockets.exception.WebSocketProcessingException;
+import io.github.elpis.reactive.websockets.handler.validation.ReactiveJSR303ValidationHandler;
 import io.github.elpis.reactive.websockets.mapper.JsonMapper;
 import io.github.elpis.reactive.websockets.session.ReactiveWebSocketSession;
 import io.github.elpis.reactive.websockets.session.ReactiveWebSocketSessionRegistry;
 import io.github.elpis.reactive.websockets.session.SessionStreams;
 import io.github.elpis.reactive.websockets.session.WebSocketSessionContext;
 import io.github.elpis.reactive.websockets.util.TypeUtils;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.MethodParameter;
@@ -38,6 +43,8 @@ import reactor.core.publisher.Mono;
  */
 @Configuration
 public class ReactiveWebSocketParameterResolverConfiguration {
+  private static final Logger log =
+      LoggerFactory.getLogger(ReactiveWebSocketParameterResolverConfiguration.class);
 
   /**
    * Resolver for Spring's native @AuthenticationPrincipal annotation Resolves the principal by
@@ -81,7 +88,9 @@ public class ReactiveWebSocketParameterResolverConfiguration {
    */
   @Bean
   public ReactiveWebSocketMethodParameterResolver requestBodyParameterResolver(
-      final ReactiveWebSocketSessionRegistry sessionRegistry, final JsonMapper jsonMapper) {
+      final ReactiveWebSocketSessionRegistry sessionRegistry,
+      final JsonMapper jsonMapper,
+      final ObjectProvider<ReactiveJSR303ValidationHandler> validationHandlerProvider) {
     return new ReactiveWebSocketMethodParameterResolver() {
       @Override
       public boolean supports(final MethodParameter parameter) {
@@ -118,15 +127,42 @@ public class ReactiveWebSocketParameterResolverConfiguration {
           return isFlux ? messages : messages.next();
         }
 
+        final boolean isValidationAvailable = validationHandlerProvider.getIfAvailable() != null;
+        final Optional<Valid> validationAnnotation =
+            Optional.ofNullable(parameter.getParameterAnnotation(Valid.class));
+        if (validationAnnotation.isPresent() && !isValidationAvailable) {
+          if (log.isDebugEnabled()) {
+            log.debug(
+                "JSR-303 validation requested for @RequestBody parameter `{}`, but no JSR-303 ValidationHandler is configured.",
+                parameter.getParameter().getName());
+          }
+        }
+
         if (isFlux) {
           return messages
               .map(WebSocketMessage::getPayloadAsText)
-              .map(text -> jsonMapper.deserialize(text, genericClass));
+              .map(text -> jsonMapper.deserialize(text, genericClass))
+              .flatMap(
+                  converted -> {
+                    if (validationAnnotation.isPresent() && isValidationAvailable) {
+                      return validationHandlerProvider.getIfAvailable().validate(converted);
+                    }
+
+                    return Mono.just(converted);
+                  });
         } else {
           return messages
               .next()
               .map(WebSocketMessage::getPayloadAsText)
-              .map(text -> jsonMapper.deserialize(text, genericClass));
+              .map(text -> jsonMapper.deserialize(text, genericClass))
+              .flatMap(
+                  converted -> {
+                    if (validationAnnotation.isPresent() && isValidationAvailable) {
+                      return validationHandlerProvider.getIfAvailable().validate(converted);
+                    }
+
+                    return Mono.just(converted);
+                  });
         }
       }
 

--- a/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/context/ReactiveWebSocketParameterResolverConfiguration.java
+++ b/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/context/ReactiveWebSocketParameterResolverConfiguration.java
@@ -11,6 +11,7 @@ import io.github.elpis.reactive.websockets.session.WebSocketSessionContext;
 import io.github.elpis.reactive.websockets.util.TypeUtils;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,26 +144,16 @@ public class ReactiveWebSocketParameterResolverConfiguration {
               .map(WebSocketMessage::getPayloadAsText)
               .map(text -> jsonMapper.deserialize(text, genericClass))
               .flatMap(
-                  converted -> {
-                    if (validationAnnotation.isPresent() && isValidationAvailable) {
-                      return validationHandlerProvider.getIfAvailable().validate(converted);
-                    }
-
-                    return Mono.just(converted);
-                  });
+                  converted ->
+                      this.tryValidate(converted, validationAnnotation, isValidationAvailable));
         } else {
           return messages
               .next()
               .map(WebSocketMessage::getPayloadAsText)
               .map(text -> jsonMapper.deserialize(text, genericClass))
               .flatMap(
-                  converted -> {
-                    if (validationAnnotation.isPresent() && isValidationAvailable) {
-                      return validationHandlerProvider.getIfAvailable().validate(converted);
-                    }
-
-                    return Mono.just(converted);
-                  });
+                  converted ->
+                      this.tryValidate(converted, validationAnnotation, isValidationAvailable));
         }
       }
 
@@ -183,6 +174,18 @@ public class ReactiveWebSocketParameterResolverConfiguration {
             () ->
                 "@RequestBody Flux/Mono must have a generic type parameter. Found raw type: %s"
                     .formatted(parameter.getParameterType()));
+      }
+
+      private Mono<?> tryValidate(
+          final Object converted,
+          final Optional<Valid> validationAnnotation,
+          final boolean isValidationAvailable) {
+        if (validationAnnotation.isPresent() && isValidationAvailable) {
+          return Objects.requireNonNull(validationHandlerProvider.getIfAvailable())
+              .validate(converted);
+        }
+
+        return Mono.just(converted);
       }
     };
   }

--- a/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/context/ReactiveWebSocketValidationConfiguration.java
+++ b/reactive-websockets-starter/src/main/java/io/github/elpis/reactive/websockets/config/context/ReactiveWebSocketValidationConfiguration.java
@@ -1,0 +1,62 @@
+package io.github.elpis.reactive.websockets.config.context;
+
+import io.github.elpis.reactive.websockets.handler.validation.ReactiveJSR303ValidationHandler;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that sets up JSR-303 validation for WebSocket messages if enabled.
+ *
+ * @author Phillip J. Fry
+ * @see org.springframework.context.annotation.Configuration
+ * @since 1.0.0
+ */
+@Configuration
+@ConditionalOnProperty(
+    name = "spring.webflux.reactive.websockets.validation.jsr303.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class ReactiveWebSocketValidationConfiguration {
+
+  /**
+   * Creates a default ValidatorFactory bean if none is present in the application context.
+   *
+   * @return a ValidatorFactory instance
+   * @since 1.0.0
+   */
+  @Bean
+  @ConditionalOnMissingBean(ValidatorFactory.class)
+  public ValidatorFactory validatorFactory() {
+    return Validation.buildDefaultValidatorFactory();
+  }
+
+  /**
+   * Creates a Validator bean using the provided ValidatorFactory if none is present.
+   *
+   * @param validatorFactory the ValidatorFactory to create the Validator from
+   * @return a Validator instance
+   * @since 1.0.0
+   */
+  @Bean
+  @ConditionalOnMissingBean(Validator.class)
+  public Validator validator(final ValidatorFactory validatorFactory) {
+    return validatorFactory.getValidator();
+  }
+
+  /**
+   * Creates a ReactiveJSR303ValidationHandler bean using the provided Validator.
+   *
+   * @param validator the Validator to be used for validation
+   * @return a ReactiveJSR303ValidationHandler instance
+   * @since 1.0.0
+   */
+  @Bean
+  public ReactiveJSR303ValidationHandler jsr303ValidationHandler(final Validator validator) {
+    return new ReactiveJSR303ValidationHandler(validator);
+  }
+}

--- a/reactive-websockets-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/reactive-websockets-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -44,6 +44,12 @@
   ],
   "properties": [
     {
+      "name": "spring.webflux.reactive.websockets.validation.jsr303.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable or disable JSR-303 validation for WebSocket messages.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.webflux.reactive.websockets.flow-control.enabled",
       "type": "java.lang.Boolean",
       "description": "Enable or disable all flow control mechanisms globally.",


### PR DESCRIPTION
# Pull Request [RWS-40](https://elpisdev.youtrack.cloud/projects/RWS/issues/RWS-40)

## Description ✍️
Integrate JSR-303 Bean Validation (@Valid on parameters of @OnMessage marked method)
Auto-send validation errors back to client with clear field-level error messages.

## Type of Change ⚙️
- [ ] 🐛 Bug Fix
- [X] ✨ New Feature
- [ ] 💥 Breaking Change
- [ ] 📚 Documentation Update
- [ ] 🛠️ Refactoring
- [ ] 🚀 Performance Improvement
- [ ] 🧪 Tests
- [ ] 🔧 Other (please specify):
